### PR TITLE
Add dissertation committee metadata commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,22 @@ Get Started
 3. Open `thesis_template.tex`, look around, and start writing!
 
 Alternatively, the template is also available from [Overleaf](https://www.overleaf.com/latex/templates/university-of-chicago-phd-dissertation-template/syvxgkqhvqqt).
+
+Committee Information
+---------------------
+
+The title page now supports committee details in addition to the existing
+metadata. Set the chair, optional co-chair, and committee members in your
+document preamble using the following commands:
+
+```tex
+\chair{Ada Lovelace}
+\cochair{Alan Turing} % optional
+\committeeMember{Grace Hopper}
+\committeeMember{Katherine Johnson}
+% or provide a comma-separated list in a single command
+\committeeMembers{Claude Shannon, Donald Knuth}
+```
+
+Any number of `\committeeMember` commands may be used. If `\cochair` is not
+provided it will be omitted from the title page automatically.

--- a/thesis.tex
+++ b/thesis.tex
@@ -17,6 +17,11 @@
 \division{Thesis Division}
 \degree{Type of Degree}
 \date{Graduation Date}
+\chair{Committee Chair}
+\cochair{Committee Co-Chair}
+\committeeMember{Committee Member One}
+\committeeMember{Committee Member Two}
+\committeeMember{Committee Member Three}
 
 \title{\thesistitle}
 \author{\thesisauthor}

--- a/ucetd.cls
+++ b/ucetd.cls
@@ -55,13 +55,20 @@
 	\addtocounter{page}{1}
 }
 
+% Committee metadata defaults
+\newif\if@committeeinfo
+\@committeeinfofalse
+\let\@chair\@empty
+\let\@cochair\@empty
+\let\@committeeMembers\@empty
+
 % UC ETD title page format
 \newcommand{\etdTitlePage} {
-	\hypersetup{pageanchor=false}
-	\begin{titlepage}
-		\begin{center}
-			\rule{0in}{0.55in} % Artificial extra [old=0.95in] margin. Why not vspace?
-			THE UNIVERSITY OF CHICAGO\\
+        \hypersetup{pageanchor=false}
+        \begin{titlepage}
+                \begin{center}
+                        \rule{0in}{0.55in} % Artificial extra [old=0.95in] margin. Why not vspace?
+                        THE UNIVERSITY OF CHICAGO\\
 			\vspace{0.8in}
 			\MakeUppercase{\@title}\\
 			\vspace{1.0in}
@@ -72,14 +79,32 @@
 			\ \\
 			DEPARTMENT OF \MakeUppercase{\@department}\\
 			\vspace{1.0in}
-			BY\\
-			\MakeUppercase{\@author}\\
-			\vspace{0.8in}
-			CHICAGO, ILLINOIS\\
-			\MakeUppercase{\@date}
-			\vspace*{0.45in}
-		\end{center}
-	\end{titlepage}
+                        BY\\
+                        \MakeUppercase{\@author}\\
+                        \if@committeeinfo
+                                \vspace{0.65in}
+                                DISSERTATION COMMITTEE\\[0.25in]
+                                \ifx\@chair\@empty\else
+                                        CHAIR\\
+                                        \MakeUppercase{\@chair}\\[0.15in]
+                                \fi
+                                \ifx\@cochair\@empty\else
+                                        CO-CHAIR\\
+                                        \MakeUppercase{\@cochair}\\[0.15in]
+                                \fi
+                                \ifx\@committeeMembers\@empty\else
+                                        COMMITTEE MEMBERS\\
+                                        \@committeeMembers\\[0.15in]
+                                \fi
+                                \vspace{0.5in}
+                        \else
+                                \vspace{0.8in}
+                        \fi
+                        CHICAGO, ILLINOIS\\
+                        \MakeUppercase{\@date}
+                        \vspace*{0.45in}
+                \end{center}
+        \end{titlepage}
 	\hypersetup{pageanchor=true}
 }
 
@@ -216,6 +241,35 @@
 \newcommand{\division}[1]{\gdef\@division{#1}}
 \newcommand{\degree}[1]{\gdef\@degree{#1}}
 \renewcommand{\date}[1]{\gdef\@date{#1}}
+
+% Dissertation committee information
+\newcommand{\chair}[1]{\gdef\@chair{#1}\@committeeinfotrue}
+\newcommand{\cochair}[1]{\gdef\@cochair{#1}\@committeeinfotrue}
+\newcommand{\committeeMember}[1]{%
+        \@committeeinfotrue
+        \ifx\@committeeMembers\@empty
+                \gdef\@committeeMembers{\MakeUppercase{#1}}%
+        \else
+                \g@addto@macro\@committeeMembers{\\\MakeUppercase{#1}}%
+        \fi
+}
+\newcommand{\committeeMembers}[1]{%
+        \let\@committeeMembers\@empty
+        \def\@etdtmp{#1}%
+        \@for\@etdmember:=\@etdtmp\do{%
+                \edef\@etdmember{\expandafter\trim@spaces\expandafter{\@etdmember}}%
+                \ifx\@etdmember\@empty\else
+                        \committeeMember{\@etdmember}%
+                \fi
+        }%
+        \ifx\@committeeMembers\@empty
+                \ifx\@chair\@empty
+                        \ifx\@cochair\@empty
+                                \@committeeinfofalse
+                        \fi
+                \fi
+        \fi
+}
 
 % Output title page
 \renewcommand{\maketitle}{


### PR DESCRIPTION
## Summary
- add support in the class file for recording a chair, optional co-chair, and any number of committee members and render the information on the title page
- update the example thesis preamble to demonstrate the new metadata commands and document them in the README

## Testing
- not run (LaTeX toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e52f253ed8832e808d642c6e375018